### PR TITLE
Standardize on command, input param and option param argument nomenclature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,12 @@ include_directories(
 add_subdirectory(src)
 
 if( IN_COMMAND_TEST )
+    cmake_policy(SET CMP0135 NEW)
+    
     include(FetchContent)
     FetchContent_Declare(
       googletest
-      URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+      URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
     )
 
     # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/inc/InCommand.h
+++ b/inc/InCommand.h
@@ -443,26 +443,26 @@ namespace InCommand
     };
 
     //------------------------------------------------------------------------------------------------
-    class CCommandCtx
+    class CCommand
     {
         int m_ScopeId = 0;
         std::string m_Name;
         std::string m_Description;
         std::map<std::string, std::shared_ptr<CParameter>> m_Parameters;
         std::map<char, std::shared_ptr<CParameter>> m_ShortOptions;
-        std::map<std::string, std::shared_ptr<CCommandCtx>> m_Subcommands;
+        std::map<std::string, std::shared_ptr<CCommand>> m_Subcommands;
         std::vector<std::shared_ptr<CParameter>> m_InputParameters;
-        CCommandCtx* m_pSuperScope = nullptr;
+        CCommand* m_pSuperScope = nullptr;
 
-        CCommandCtx* ReadCommandArguments(class CCommandReader *pReader);
+        CCommand* ReadCommandArguments(class CCommandReader *pReader);
         Status ReadParameterArguments(class CCommandReader *pReader) const;
 
     public:
-        CCommandCtx(const char* name, const char* description, int scopeId = 0);
-        CCommandCtx(CCommandCtx&& o) = delete;
-        ~CCommandCtx() = default;
+        CCommand(const char* name, const char* description, int scopeId = 0);
+        CCommand(CCommand&& o) = delete;
+        ~CCommand() = default;
 
-        CCommandCtx* DeclareCommandCtx(const char* name, const char* description, int scopeId = 0);
+        CCommand* DeclareCommand(const char* name, const char* description, int scopeId = 0);
         const CParameter* DeclareInputParameter(Value &value, const char* name, const char* description);
         const CParameter* DeclareBoolParameter(Bool &value, const char* name, const char* description, char shortKey = 0);
         const CParameter* DeclareOptionParameter(Value& value, const char* name, const char* description, char shortKey = 0);
@@ -483,14 +483,14 @@ namespace InCommand
     //------------------------------------------------------------------------------------------------
     class CCommandReader
     {
-        CCommandCtx m_DefaultCtx;
+        CCommand m_DefaultCtx;
         CArgumentList m_ArgList;
         CArgumentIterator m_ArgIt;
-        CCommandCtx* m_pActiveCtx = nullptr;
+        CCommand* m_pActiveCtx = nullptr;
         Status m_LastStatus = Status::Success;
         size_t m_ParametersRead = 0;
 
-        friend class CCommandCtx;
+        friend class CCommand;
 
     public:
         CCommandReader(const char* appName, const char *defaultDescription, int argc, const char* argv[]);
@@ -504,18 +504,18 @@ namespace InCommand
         }
 
         // Returns the default command context pointer, used for declaring subcommands.
-        CCommandCtx* DefaultCommandCtx() { return &m_DefaultCtx; }
+        CCommand* DefaultCommand() { return &m_DefaultCtx; }
 
         // Returns the active command context pointer, or nullptr if the active command
         // has not been fetched.
-        CCommandCtx* ActiveCommandCtx() { return m_pActiveCtx; }
+        CCommand* ActiveCommand() { return m_pActiveCtx; }
 
         // Reads the command arguments from the argument list
         // and returns the matching command context.
         // Afterward, the argument iterator index points to
         // the first option argument in the argument list.
         // Allows the application to delay-declare command options.
-        CCommandCtx* ReadCommandArguments();
+        CCommand* ReadCommandArguments();
 
         // Reads the parameter values from the argument list, setting the bound values.
         // Requires the active command be set by calling ReadActiveCommand.

--- a/inc/InCommand.h
+++ b/inc/InCommand.h
@@ -37,7 +37,6 @@ namespace InCommand
     {
         Input,
         Option,
-        Bool
     };
 
     //------------------------------------------------------------------------------------------------
@@ -370,46 +369,22 @@ namespace InCommand
     };
 
     //------------------------------------------------------------------------------------------------
-    class CBoolParameter : public CParameter
+    template<class _T>
+    class TOptionParameter : public CParameter
     {
-        Bool& m_value;
-
-    public:
-        CBoolParameter(Bool &value, const char* name, const char* description, char shortKey = 0) :
-            CParameter(name, description),
-            m_value(value)
-        {
-            m_shortKey = shortKey;
-        }
-
-        virtual ParameterType Type() const final { return ParameterType::Bool; }
-        virtual Status ParseArgs(const CArgumentList& args, CArgumentIterator& it) const final
-        {
-            if (it == args.End())
-                return Status::Success;
-
-            m_value = true; // Present means true
-            ++it;
-
-            return Status::Success;
-        }
-    };
-
-    //------------------------------------------------------------------------------------------------
-    class COptionParameter : public CParameter
-    {
-        Value &m_value;
+    protected:
+        _T &m_value;
         Domain m_domain;
 
     public:
-        COptionParameter(Value &value, const char* name, const char* description, char shortKey = 0) :
+        TOptionParameter(_T &value, const char* name, const char* description, char shortKey = 0) :
             CParameter(name, description),
             m_value(value)
         {
             m_shortKey = shortKey;
         }
 
-        COptionParameter(Value& value, const char* name, const Domain &domain, const char* description, char shortKey = 0) :
+        TOptionParameter(_T& value, const char* name, const Domain &domain, const char* description, char shortKey = 0) :
             CParameter(name, description),
             m_value(value),
             m_domain(domain)
@@ -418,7 +393,7 @@ namespace InCommand
         }
 
         virtual ParameterType Type() const final { return ParameterType::Option; }
-        virtual Status ParseArgs(const CArgumentList& args, CArgumentIterator& it) const final
+        virtual Status ParseArgs(const CArgumentList& args, CArgumentIterator& it) const
         {
             ++it;
 
@@ -438,6 +413,31 @@ namespace InCommand
                 return result;
 
             ++it;
+            return Status::Success;
+        }
+    };
+
+    using COptionParameter = TOptionParameter<Value>;
+
+    //------------------------------------------------------------------------------------------------
+    class CBoolParameter : public TOptionParameter<CTypedValue<bool>>
+    {
+    public:
+        CBoolParameter(Bool &value, const char* name, const char* description, char shortKey = 0) :
+            TOptionParameter(value, name, description, shortKey)
+        {}
+
+        virtual Status ParseArgs(const CArgumentList& args, CArgumentIterator& it) const final
+        {
+            if (it == args.End())
+            {
+                m_value = false; // Not present means falseS
+                return Status::Success;
+            }
+
+            m_value = true; // = CTypedValue<bool>(true); // Present means true
+            ++it;
+
             return Status::Success;
         }
     };

--- a/inc/InCommand.h
+++ b/inc/InCommand.h
@@ -484,7 +484,7 @@ namespace InCommand
         CCommand m_RootCommand;
         CArgumentList m_ArgList;
         CArgumentIterator m_ArgIt;
-        CCommand* m_pActiveCtx = nullptr;
+        CCommand* m_pActiveCommand = nullptr;
         Status m_LastStatus = Status::Success;
         size_t m_ParametersRead = 0;
 
@@ -506,7 +506,7 @@ namespace InCommand
 
         // Returns the active command context pointer, or nullptr if the active command
         // has not been fetched.
-        CCommand* ActiveCommand() { return m_pActiveCtx; }
+        CCommand* ActiveCommand() { return m_pActiveCommand; }
 
         // Reads the command arguments from the argument list
         // and returns the matching command context.

--- a/inc/InCommand.h
+++ b/inc/InCommand.h
@@ -483,7 +483,7 @@ namespace InCommand
     //------------------------------------------------------------------------------------------------
     class CCommandReader
     {
-        CCommand m_DefaultCtx;
+        CCommand m_RootCommand;
         CArgumentList m_ArgList;
         CArgumentIterator m_ArgIt;
         CCommand* m_pActiveCtx = nullptr;
@@ -504,7 +504,7 @@ namespace InCommand
         }
 
         // Returns the default command context pointer, used for declaring subcommands.
-        CCommand* DefaultCommand() { return &m_DefaultCtx; }
+        CCommand* RootCommand() { return &m_RootCommand; }
 
         // Returns the active command context pointer, or nullptr if the active command
         // has not been fetched.

--- a/inc/InCommand.h
+++ b/inc/InCommand.h
@@ -454,8 +454,6 @@ namespace InCommand
         std::vector<std::shared_ptr<CParameter>> m_InputParameters;
         CCommand* m_pSuperScope = nullptr;
 
-        CCommand* ReadCommandArguments(class CCommandReader *pReader);
-        Status ReadParameterArguments(class CCommandReader *pReader) const;
 
     public:
         CCommand(const char* name, const char* description, int scopeId = 0);

--- a/readme.md
+++ b/readme.md
@@ -1,94 +1,86 @@
 # Introduction
 
-This is a work-in-progress. Most of the primary features are functional, but quite a bit of polish is still needed.
+This is a work in progress. Most of the primary features are functional, but quite a bit of polish is still needed.
 
-InCommand is a command line parsing utility. Command lines are expected to have the following syntax:
-
-```
-app-name [command [command[...]]] [options...]
-```
-
-# Arguments
-
-Arguments are the space-delimitted strings in a command line. Typically, these are passed into the main function in a program's main function as 'argv'.
-
-```C
-int main(int argc, const char *argv[])
-```
-
-Arguments are either commands or options, with commands appearing before any options in the argument list.
-
----
-
-## Command Arguments
-
-A sequence of command arguments describes a command context. If no command arguments are given the default command is active. A command context is declared as either a subcontext of the default command context or of another declared command context.
-
-Command arguments must be at the start of the argument list, preceding any option arguments. Only one command context is active in a given command line.
-
-Example:
+InCommand is a command line interface (CLI) argument processor. Command lines are expected to have the following syntax:
 
 ```
-foo.exe subcom-A subcom-B-of-A subcom-C-of-B-of-A --switch-on-subcom-C-of-B-of-A
+app-name [command args...] [parameter args...]
 ```
 
 ---
 
-## Parameter Options
+## Definition of Terms
 
-Parameter options contain only a value. Typically, parameter arguments do not start with '--' or '-', as these give the appearance of variable or switch options.
+### Arguments
 
-Any option argument that doesn't begin with '--' or '-' is assumed to be a parameter value. Values are assigned to parameters in the order they are declared. An error is produced if there are more parameters in the argument list than declared parameters.
+Arguments are the elements of a command representing individual action or parameter arguments.
+
+### Command Arguments
+
+Command arguments describe the action that a command needs to perform.
+
+### Command Context
+
+A command context encapsulates a given command argument and defines the parameter rules for the context. Command contexts may be nested to support rich command syntax. For example, command context nesting can be useful for creating command categories:
+
+``` sh
+fooApp config reset
+```
+
+In this case, the command argument 'reset' is nested with the command argument 'config'.
+
+Command arguments must be at the start of the argument list, preceding any parameter arguments. Only one action is active in a given command.
+
+### Parameter Arguments
+
+Parameter arguments are given after command arguments. Parameter arguments can either be options or inputs.
+
+### Option Parameter Arguments
+
+Option argument strings are prefixed with `--`. Option argument types and values are constrained by the rules set in a declared command context.
+
+Option parameters are typed. Boolean options are `true` if they are present in the command arguments.
 
 Example:
 
-```
-foo.exe myfile1.foo myfile2.foo
-```
-
----
-
-## Variable and Switch Options
-
-Syntactically, variable and switch option arguments use '--' followed by the name of the option. Optionally, a single letter short-form label may be declared, which is preceded by a single hyphen '-'.
-
-Example
-```
-foo.exe --long-option-name
+``` sh
+fooApp config reset --force
 ```
 
-or
-
-```
-foo.exe -l
-```
-
-### Switch Options
-
-Switch options are boolean values considered to be 'on' when present in the options list. 
+All other option parameters must be immediately followed by an input value of a matching type.
 
 Example:
 
-```
-foo.exe --reset
+``` sh
+fooApp config reset --mode quick
 ```
 
-### Variable Options
-
-Variable arguments are name/value string pairs. The value string is taken from the next argument in the argument list. A default value is assigned if the variable is not present in the argument list.
+If needed, option parameter values can be constrained to a limited domain of input values.
 
 Example:
 
-```
-foo.exe --file hello.txt
+Assume option 'color' is declared as constrained to the set ['red', 'green', 'blue']
+
+``` sh
+fooApp --color red
 ```
 
-Variable options may be constrained to a pre-declared domain of values. An error results if an assigned value is not in the domain.
+InCommand supports optional short-form single letter aliases for option parameter arguments. Short-form options are preceded by `-` instead of `--`.
 
 Example:
 
-Assume Variable 'color' is declared as constrained to the set ['red', 'green', 'blue']
-
+``` sh
+fooApp --long-option-name
+fooApp -l
 ```
-foo.exe --color red
+
+### Input Parameter Arguments
+
+Input parameter arguments have no prefix like `--` or `-`. The number if input parameters is constrained by the associate command context or option parameter rules.
+
+Example:
+
+``` sh
+fooApp merge myfile1.foo myfile2.foo --outfile mergedfile.foo
 ```

--- a/src/lib/InCommand.cpp
+++ b/src/lib/InCommand.cpp
@@ -28,7 +28,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    CCommandCtx::CCommandCtx(const char* name, const char* description, int scopeId) :
+    CCommand::CCommand(const char* name, const char* description, int scopeId) :
         m_ScopeId(scopeId),
         m_Description(description ? description : "")
     {
@@ -37,9 +37,9 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    CCommandCtx* CCommandCtx::ReadCommandArguments(CCommandReader* pReader)
+    CCommand* CCommand::ReadCommandArguments(CCommandReader* pReader)
     {
-        CCommandCtx *pScope = this;
+        CCommand *pScope = this;
 
         ++pReader->m_ArgIt;
         if (pReader->m_ArgIt != pReader->m_ArgList.End())
@@ -55,7 +55,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    Status CCommandCtx::ReadParameterArguments(CCommandReader *pReader) const
+    Status CCommand::ReadParameterArguments(CCommandReader *pReader) const
     {
         Status result = Status::Success;
 
@@ -120,19 +120,19 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    CCommandCtx* CCommandCtx::DeclareCommandCtx(const char* name, const char* description, int scopeId)
+    CCommand* CCommand::DeclareCommand(const char* name, const char* description, int scopeId)
     {
         auto it = m_Subcommands.find(name);
         if (it != m_Subcommands.end())
             throw Exception(Status::DuplicateCommand);
 
-        auto result = m_Subcommands.emplace(name, std::make_shared<CCommandCtx>(name, description, scopeId));
+        auto result = m_Subcommands.emplace(name, std::make_shared<CCommand>(name, description, scopeId));
         result.first->second->m_pSuperScope = this;
         return result.first->second.get();
     }
 
     //------------------------------------------------------------------------------------------------
-    std::string CCommandCtx::CommandChainString() const
+    std::string CCommand::CommandChainString() const
     {
         std::ostringstream s;
         if (m_pSuperScope)
@@ -147,7 +147,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    std::string CCommandCtx::UsageString() const
+    std::string CCommand::UsageString() const
     {
         std::ostringstream s;
         s << m_Description << std::endl;
@@ -229,7 +229,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    const CParameter* CCommandCtx::DeclareBoolParameter(Bool& boundValue, const char* name, const char *description, char shortKey)
+    const CParameter* CCommand::DeclareBoolParameter(Bool& boundValue, const char* name, const char *description, char shortKey)
     {
         auto it = m_Parameters.find(name);
         if (it != m_Parameters.end())
@@ -242,7 +242,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    const CParameter* CCommandCtx::DeclareOptionParameter(Value& boundValue, const char* name, const char *description, char shortKey)
+    const CParameter* CCommand::DeclareOptionParameter(Value& boundValue, const char* name, const char *description, char shortKey)
     {
         auto it = m_Parameters.find(name);
         if (it != m_Parameters.end())
@@ -255,7 +255,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    const CParameter* CCommandCtx::DeclareOptionParameter(Value& boundValue, const char* name, int domainSize, const char* domainValueStrings[], const char *description, char shortKey)
+    const CParameter* CCommand::DeclareOptionParameter(Value& boundValue, const char* name, int domainSize, const char* domainValueStrings[], const char *description, char shortKey)
     {
         auto it = m_Parameters.find(name);
         if (it != m_Parameters.end())
@@ -269,7 +269,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    const CParameter* CCommandCtx::DeclareOptionParameter(Value& boundValue, const char* name, const Domain &domain, const char* description, char shortKey)
+    const CParameter* CCommand::DeclareOptionParameter(Value& boundValue, const char* name, const Domain &domain, const char* description, char shortKey)
     {
         auto it = m_Parameters.find(name);
         if (it != m_Parameters.end())
@@ -282,7 +282,7 @@ namespace InCommand
     }
 
     //------------------------------------------------------------------------------------------------
-    const CParameter* CCommandCtx::DeclareInputParameter(Value& boundValue, const char* name, const char* description)
+    const CParameter* CCommand::DeclareInputParameter(Value& boundValue, const char* name, const char* description)
     {
         auto it = m_Parameters.find(name);
         if (it != m_Parameters.end())
@@ -306,7 +306,7 @@ namespace InCommand
     {}
 
     //------------------------------------------------------------------------------------------------
-    CCommandCtx *CCommandReader::ReadCommandArguments()
+    CCommand *CCommandReader::ReadCommandArguments()
     {
         m_ArgIt = m_ArgList.Begin();
         m_pActiveCtx = m_DefaultCtx.ReadCommandArguments(this);

--- a/src/lib/InCommand.cpp
+++ b/src/lib/InCommand.cpp
@@ -301,7 +301,7 @@ namespace InCommand
 
     //------------------------------------------------------------------------------------------------
     CCommandReader::CCommandReader(const char* appName, const char *defaultDescription, int argc, const char* argv[]) :
-        m_DefaultCtx(appName, defaultDescription, 0),
+        m_RootCommand(appName, defaultDescription, 0),
         m_ArgList(argc, argv)
     {}
 
@@ -309,7 +309,7 @@ namespace InCommand
     CCommand *CCommandReader::ReadCommandArguments()
     {
         m_ArgIt = m_ArgList.Begin();
-        m_pActiveCtx = m_DefaultCtx.ReadCommandArguments(this);
+        m_pActiveCtx = m_RootCommand.ReadCommandArguments(this);
         m_LastStatus = Status::Success;
         return m_pActiveCtx;
     }

--- a/src/lib/InCommand.cpp
+++ b/src/lib/InCommand.cpp
@@ -227,27 +227,27 @@ namespace InCommand
     {
         m_ArgIt = m_ArgList.Begin();
 
-        CCommand *pScope = &m_RootCommand;
+        CCommand *pCommand = &m_RootCommand;
 
         ++m_ArgIt;
         while (m_ArgIt != m_ArgList.End())
         {
-            auto subIt = pScope->m_Subcommands.find(m_ArgList.At(m_ArgIt));
-            if (subIt == pScope->m_Subcommands.end())
+            auto subIt = pCommand->m_Subcommands.find(m_ArgList.At(m_ArgIt));
+            if (subIt == pCommand->m_Subcommands.end())
                 break;
-            pScope = subIt->second.get();
+            pCommand = subIt->second.get();
             ++m_ArgIt;
         }
 
-        m_pActiveCtx = pScope;
+        m_pActiveCommand = pCommand;
 
-        return pScope;
+        return m_pActiveCommand;
     }
 
     //------------------------------------------------------------------------------------------------
     Status CCommandReader::ReadParameterArguments()
     {
-        if (!m_pActiveCtx)
+        if (!m_pActiveCommand)
             ReadCommandArguments();
 
         Status result = Status::Success;
@@ -267,8 +267,8 @@ namespace InCommand
                 if (m_ArgList.At(m_ArgIt)[1] == '-')
                 {
                     // Long-form option
-                    auto optIt = m_pActiveCtx->m_Parameters.find(m_ArgList.At(m_ArgIt).substr(2));
-                    if (optIt == m_pActiveCtx->m_Parameters.end() || optIt->second->Type() == ParameterType::Input)
+                    auto optIt = m_pActiveCommand->m_Parameters.find(m_ArgList.At(m_ArgIt).substr(2));
+                    if (optIt == m_pActiveCommand->m_Parameters.end() || optIt->second->Type() == ParameterType::Input)
                     {
                         result = Status::UnknownOption;
                         return result;
@@ -277,8 +277,8 @@ namespace InCommand
                 }
                 else
                 {
-                    auto optIt = m_pActiveCtx->m_ShortOptions.find(m_ArgList.At(m_ArgIt)[1]);
-                    if (optIt == m_pActiveCtx->m_ShortOptions.end())
+                    auto optIt = m_pActiveCommand->m_ShortOptions.find(m_ArgList.At(m_ArgIt)[1]);
+                    if (optIt == m_pActiveCommand->m_ShortOptions.end())
                     {
                         result = Status::UnknownOption;
                         return result;
@@ -296,13 +296,13 @@ namespace InCommand
             else
             {
                 // Assume parameter option
-                if (m_ParametersRead == m_pActiveCtx->m_InputParameters.size())
+                if (m_ParametersRead == m_pActiveCommand->m_InputParameters.size())
                 {
                     result = Status::UnexpectedArgument;
                     return result;
                 }
 
-                result = m_pActiveCtx->m_InputParameters[m_ParametersRead]->ParseArgs(m_ArgList, m_ArgIt);
+                result = m_pActiveCommand->m_InputParameters[m_ParametersRead]->ParseArgs(m_ArgList, m_ArgIt);
                 if (result != Status::Success)
                     return result;
                 m_ParametersRead++;

--- a/src/sample/Sample.cpp
+++ b/src/sample/Sample.cpp
@@ -11,23 +11,22 @@ int main(int argc, const char *argv[])
     InCommand::String Message("");
 
     InCommand::CCommandReader CmdReader("sample", "Sample app for demonstrating use of InCommand command line reader utility", argc, argv);
+    CmdReader.DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
 
-    CmdReader.RootCommand()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
-
-    InCommand::CCommand *pAddCmd = CmdReader.RootCommand()->DeclareCommand("add", "Adds two integers", 1);
+    InCommand::CCommand *pAddCmd = CmdReader.DeclareCommand("add", "Adds two integers", 1);
     pAddCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample add.", 'h');
     pAddCmd->DeclareInputParameter(Val1, "value1", "First add value");
     pAddCmd->DeclareInputParameter(Val2, "value2", "Second add value");
     pAddCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 + value2", 'm');
 
-    InCommand::CCommand *pMulCmd = CmdReader.RootCommand()->DeclareCommand("mul", "Multiplies two integers", 2);
+    InCommand::CCommand *pMulCmd = CmdReader.DeclareCommand("mul", "Multiplies two integers", 2);
     pMulCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample multiply.", 'h');
     pMulCmd->DeclareInputParameter(Val1, "value1", "First multiply value");
     pMulCmd->DeclareInputParameter(Val2, "value2", "Second multiply value");
     pMulCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 * value2", 'm');
 
-    InCommand::CCommand *pCmd = CmdReader.ReadCommandArguments();
-    InCommand::Status fetchResult = CmdReader.ReadParameterArguments();
+    const InCommand::CCommand *pCmd = CmdReader.PreReadCommandArguments();
+    InCommand::Status fetchResult = CmdReader.ReadParameterArguments(pCmd);
     if (InCommand::Status::Success != fetchResult)
     {
         std::cout << std::endl;

--- a/src/sample/Sample.cpp
+++ b/src/sample/Sample.cpp
@@ -12,21 +12,21 @@ int main(int argc, const char *argv[])
 
     InCommand::CCommandReader CmdReader("sample", "Sample app for demonstrating use of InCommand command line reader utility", argc, argv);
 
-    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
+    CmdReader.DefaultCommand()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
 
-    InCommand::CCommandCtx *pAddCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("add", "Adds two integers", 1);
+    InCommand::CCommand *pAddCmd = CmdReader.DefaultCommand()->DeclareCommand("add", "Adds two integers", 1);
     pAddCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample add.", 'h');
     pAddCmd->DeclareInputParameter(Val1, "value1", "First add value");
     pAddCmd->DeclareInputParameter(Val2, "value2", "Second add value");
     pAddCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 + value2", 'm');
 
-    InCommand::CCommandCtx *pMulCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("mul", "Multiplies two integers", 2);
+    InCommand::CCommand *pMulCmd = CmdReader.DefaultCommand()->DeclareCommand("mul", "Multiplies two integers", 2);
     pMulCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample multiply.", 'h');
     pMulCmd->DeclareInputParameter(Val1, "value1", "First multiply value");
     pMulCmd->DeclareInputParameter(Val2, "value2", "Second multiply value");
     pMulCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 * value2", 'm');
 
-    InCommand::CCommandCtx *pCmd = CmdReader.ReadCommandArguments();
+    InCommand::CCommand *pCmd = CmdReader.ReadCommandArguments();
     InCommand::Status fetchResult = CmdReader.ReadParameterArguments();
     if (InCommand::Status::Success != fetchResult)
     {

--- a/src/sample/Sample.cpp
+++ b/src/sample/Sample.cpp
@@ -12,15 +12,15 @@ int main(int argc, const char *argv[])
 
     InCommand::CCommandReader CmdReader("sample", "Sample app for demonstrating use of InCommand command line reader utility", argc, argv);
 
-    CmdReader.DefaultCommand()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
+    CmdReader.RootCommand()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
 
-    InCommand::CCommand *pAddCmd = CmdReader.DefaultCommand()->DeclareCommand("add", "Adds two integers", 1);
+    InCommand::CCommand *pAddCmd = CmdReader.RootCommand()->DeclareCommand("add", "Adds two integers", 1);
     pAddCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample add.", 'h');
     pAddCmd->DeclareInputParameter(Val1, "value1", "First add value");
     pAddCmd->DeclareInputParameter(Val2, "value2", "Second add value");
     pAddCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 + value2", 'm');
 
-    InCommand::CCommand *pMulCmd = CmdReader.DefaultCommand()->DeclareCommand("mul", "Multiplies two integers", 2);
+    InCommand::CCommand *pMulCmd = CmdReader.RootCommand()->DeclareCommand("mul", "Multiplies two integers", 2);
     pMulCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample multiply.", 'h');
     pMulCmd->DeclareInputParameter(Val1, "value1", "First multiply value");
     pMulCmd->DeclareInputParameter(Val2, "value2", "Second multiply value");

--- a/src/sample/Sample.cpp
+++ b/src/sample/Sample.cpp
@@ -5,30 +5,30 @@
 
 int main(int argc, const char *argv[])
 {
-    InCommand::InCommandBool ShowHelp;
-    InCommand::InCommandInt Val1;
-    InCommand::InCommandInt Val2;
-    InCommand::InCommandString Message("");
+    InCommand::Bool ShowHelp;
+    InCommand::Int Val1;
+    InCommand::Int Val2;
+    InCommand::String Message("");
 
     InCommand::CCommandReader CmdReader("sample", "Sample app for demonstrating use of InCommand command line reader utility", argc, argv);
 
-    CmdReader.DefaultCommandCtx()->DeclareSwitchOption(ShowHelp, "help", "Display help for sample commands.", 'h');
+    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(ShowHelp, "help", "Display help for sample commands.", 'h');
 
     InCommand::CCommandCtx *pAddCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("add", "Adds two integers", 1);
-    pAddCmd->DeclareSwitchOption(ShowHelp, "help", "Display help for sample add.", 'h');
-    pAddCmd->DeclareParameterOption(Val1, "value1", "First add value");
-    pAddCmd->DeclareParameterOption(Val2, "value2", "Second add value");
-    pAddCmd->DeclareVariableOption(Message, "message", "Print <message> N-times where N = value1 + value2", 'm');
+    pAddCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample add.", 'h');
+    pAddCmd->DeclareInputParameter(Val1, "value1", "First add value");
+    pAddCmd->DeclareInputParameter(Val2, "value2", "Second add value");
+    pAddCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 + value2", 'm');
 
     InCommand::CCommandCtx *pMulCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("mul", "Multiplies two integers", 2);
-    pMulCmd->DeclareSwitchOption(ShowHelp, "help", "Display help for sample multiply.", 'h');
-    pMulCmd->DeclareParameterOption(Val1, "value1", "First multiply value");
-    pMulCmd->DeclareParameterOption(Val2, "value2", "Second multiply value");
-    pMulCmd->DeclareVariableOption(Message, "message", "Print <message> N-times where N = value1 * value2", 'm');
+    pMulCmd->DeclareBoolParameter(ShowHelp, "help", "Display help for sample multiply.", 'h');
+    pMulCmd->DeclareInputParameter(Val1, "value1", "First multiply value");
+    pMulCmd->DeclareInputParameter(Val2, "value2", "Second multiply value");
+    pMulCmd->DeclareOptionParameter(Message, "message", "Print <message> N-times where N = value1 * value2", 'm');
 
-    InCommand::CCommandCtx *pCmd = CmdReader.ReadCommandCtx();
-    InCommand::InCommandStatus fetchResult = CmdReader.ReadOptions();
-    if (InCommand::InCommandStatus::Success != fetchResult)
+    InCommand::CCommandCtx *pCmd = CmdReader.ReadCommandArguments();
+    InCommand::Status fetchResult = CmdReader.ReadParameterArguments();
+    if (InCommand::Status::Success != fetchResult)
     {
         std::cout << std::endl;
         std::cout << "Command Line Error: " << CmdReader.LastErrorString() << std::endl;

--- a/src/test/InCommandTest.cpp
+++ b/src/test/InCommandTest.cpp
@@ -20,9 +20,9 @@ TEST(InCommand, BasicParams)
     const char* colors[] = { "red", "green", "blue" };
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(IsReal, "is-real", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Name, "name", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Color, "color", 3, colors, nullptr);
+    CmdReader.DefaultCommand()->DeclareBoolParameter(IsReal, "is-real", nullptr);
+    CmdReader.DefaultCommand()->DeclareOptionParameter(Name, "name", nullptr);
+    CmdReader.DefaultCommand()->DeclareOptionParameter(Color, "color", 3, colors, nullptr);
 
     InCommand::CArgumentList args(argc, argv);
     InCommand::CArgumentIterator it = args.Begin();
@@ -51,10 +51,10 @@ TEST(InCommand, ParameterParams)
     InCommand::String File3;
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File1, "file1", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File2, "file2", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File3, "file3", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(SomeSwitch, "some-switch", nullptr);
+    CmdReader.DefaultCommand()->DeclareInputParameter(File1, "file1", nullptr);
+    CmdReader.DefaultCommand()->DeclareInputParameter(File2, "file2", nullptr);
+    CmdReader.DefaultCommand()->DeclareInputParameter(File3, "file3", nullptr);
+    CmdReader.DefaultCommand()->DeclareBoolParameter(SomeSwitch, "some-switch", nullptr);
 
     CmdReader.ReadParameterArguments();
 
@@ -94,17 +94,17 @@ TEST(InCommand, SubCommands)
         InCommand::String Lives("9");
 
         InCommand::CCommandReader CmdReader("app", "test argument list", 0, nullptr);
-        CmdReader.DefaultCommandCtx()->DeclareBoolParameter(Help, "help", nullptr);
-        InCommand::CCommandCtx* pPlantCommand = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("plant", nullptr, to_underlying(ScopeId::Plant));
+        CmdReader.DefaultCommand()->DeclareBoolParameter(Help, "help", nullptr);
+        InCommand::CCommand* pPlantCommand = CmdReader.DefaultCommand()->DeclareCommand("plant", nullptr, to_underlying(ScopeId::Plant));
         pPlantCommand->DeclareBoolParameter(List, "list", nullptr);
-        InCommand::CCommandCtx* pShrubCommand = pPlantCommand->DeclareCommandCtx("shrub", nullptr, to_underlying(ScopeId::Shrub));
+        InCommand::CCommand* pShrubCommand = pPlantCommand->DeclareCommand("shrub", nullptr, to_underlying(ScopeId::Shrub));
         pShrubCommand->DeclareBoolParameter(Prune, "prune", nullptr);
         pShrubCommand->DeclareBoolParameter(Burn, "burn", nullptr);
-        InCommand::CCommandCtx* pAnimalCommand = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("animal", nullptr, to_underlying(ScopeId::Animal));
-        pAnimalCommand->DeclareCommandCtx("dog", nullptr, to_underlying(ScopeId::Dog));
-        pAnimalCommand->DeclareCommandCtx("cat", nullptr, to_underlying(ScopeId::Cat));
+        InCommand::CCommand* pAnimalCommand = CmdReader.DefaultCommand()->DeclareCommand("animal", nullptr, to_underlying(ScopeId::Animal));
+        pAnimalCommand->DeclareCommand("dog", nullptr, to_underlying(ScopeId::Dog));
+        pAnimalCommand->DeclareCommand("cat", nullptr, to_underlying(ScopeId::Cat));
 
-        auto LateDeclareOptions = [&](InCommand::CCommandCtx* pCommandScope)
+        auto LateDeclareOptions = [&](InCommand::CCommand* pCommandScope)
         {
             switch (static_cast<ScopeId>(pCommandScope->Id()))
             {
@@ -137,7 +137,7 @@ TEST(InCommand, SubCommands)
             const int argc = sizeof(argv) / sizeof(argv[0]);
 
             CmdReader.Reset(argc, argv);
-            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandArguments();
+            InCommand::CCommand *pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
@@ -158,7 +158,7 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandArguments();
+            InCommand::CCommand *pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
@@ -175,7 +175,7 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommandCtx* pCtx = CmdReader.ReadCommandArguments();
+            InCommand::CCommand* pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
@@ -195,10 +195,10 @@ TEST(InCommand, Errors)
         const char* argv[] = { "app", "goto", "--foo", "--bar" };
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-        auto *pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto *pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         try
         {
-            CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);; // Duplicate command "goto"
+            CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);; // Duplicate command "goto"
         }
         catch(const InCommand::Exception& e)
         {
@@ -210,10 +210,10 @@ TEST(InCommand, Errors)
         const char* argv[] = { "app", "goto", "--foo", "--bar", "7" };
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-        CmdReader.DefaultCommandCtx()->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        CmdReader.DefaultCommand()->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         try
         {
-            CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Bar, "foo", nullptr, 0); // Duplicate option "foo"
+            CmdReader.DefaultCommand()->DeclareOptionParameter(Bar, "foo", nullptr, 0); // Duplicate option "foo"
         }
         catch (const InCommand::Exception& e)
         {
@@ -226,7 +226,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -239,7 +239,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -252,7 +252,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -265,7 +265,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -278,7 +278,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         const char* barValues[] = { "1", "3", "5" };
         pGotoCmd->DeclareOptionParameter(Bar, "bar", 3, barValues, nullptr, 0);

--- a/src/test/InCommandTest.cpp
+++ b/src/test/InCommandTest.cpp
@@ -20,9 +20,9 @@ TEST(InCommand, BasicParams)
     const char* colors[] = { "red", "green", "blue" };
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommand()->DeclareBoolParameter(IsReal, "is-real", nullptr);
-    CmdReader.DefaultCommand()->DeclareOptionParameter(Name, "name", nullptr);
-    CmdReader.DefaultCommand()->DeclareOptionParameter(Color, "color", 3, colors, nullptr);
+    CmdReader.RootCommand()->DeclareBoolParameter(IsReal, "is-real", nullptr);
+    CmdReader.RootCommand()->DeclareOptionParameter(Name, "name", nullptr);
+    CmdReader.RootCommand()->DeclareOptionParameter(Color, "color", 3, colors, nullptr);
 
     InCommand::CArgumentList args(argc, argv);
     InCommand::CArgumentIterator it = args.Begin();
@@ -51,10 +51,10 @@ TEST(InCommand, ParameterParams)
     InCommand::String File3;
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommand()->DeclareInputParameter(File1, "file1", nullptr);
-    CmdReader.DefaultCommand()->DeclareInputParameter(File2, "file2", nullptr);
-    CmdReader.DefaultCommand()->DeclareInputParameter(File3, "file3", nullptr);
-    CmdReader.DefaultCommand()->DeclareBoolParameter(SomeSwitch, "some-switch", nullptr);
+    CmdReader.RootCommand()->DeclareInputParameter(File1, "file1", nullptr);
+    CmdReader.RootCommand()->DeclareInputParameter(File2, "file2", nullptr);
+    CmdReader.RootCommand()->DeclareInputParameter(File3, "file3", nullptr);
+    CmdReader.RootCommand()->DeclareBoolParameter(SomeSwitch, "some-switch", nullptr);
 
     CmdReader.ReadParameterArguments();
 
@@ -94,13 +94,13 @@ TEST(InCommand, SubCommands)
         InCommand::String Lives("9");
 
         InCommand::CCommandReader CmdReader("app", "test argument list", 0, nullptr);
-        CmdReader.DefaultCommand()->DeclareBoolParameter(Help, "help", nullptr);
-        InCommand::CCommand* pPlantCommand = CmdReader.DefaultCommand()->DeclareCommand("plant", nullptr, to_underlying(ScopeId::Plant));
+        CmdReader.RootCommand()->DeclareBoolParameter(Help, "help", nullptr);
+        InCommand::CCommand* pPlantCommand = CmdReader.RootCommand()->DeclareCommand("plant", nullptr, to_underlying(ScopeId::Plant));
         pPlantCommand->DeclareBoolParameter(List, "list", nullptr);
         InCommand::CCommand* pShrubCommand = pPlantCommand->DeclareCommand("shrub", nullptr, to_underlying(ScopeId::Shrub));
         pShrubCommand->DeclareBoolParameter(Prune, "prune", nullptr);
         pShrubCommand->DeclareBoolParameter(Burn, "burn", nullptr);
-        InCommand::CCommand* pAnimalCommand = CmdReader.DefaultCommand()->DeclareCommand("animal", nullptr, to_underlying(ScopeId::Animal));
+        InCommand::CCommand* pAnimalCommand = CmdReader.RootCommand()->DeclareCommand("animal", nullptr, to_underlying(ScopeId::Animal));
         pAnimalCommand->DeclareCommand("dog", nullptr, to_underlying(ScopeId::Dog));
         pAnimalCommand->DeclareCommand("cat", nullptr, to_underlying(ScopeId::Cat));
 
@@ -195,10 +195,10 @@ TEST(InCommand, Errors)
         const char* argv[] = { "app", "goto", "--foo", "--bar" };
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-        auto *pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto *pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         try
         {
-            CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);; // Duplicate command "goto"
+            CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);; // Duplicate command "goto"
         }
         catch(const InCommand::Exception& e)
         {
@@ -210,10 +210,10 @@ TEST(InCommand, Errors)
         const char* argv[] = { "app", "goto", "--foo", "--bar", "7" };
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-        CmdReader.DefaultCommand()->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        CmdReader.RootCommand()->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         try
         {
-            CmdReader.DefaultCommand()->DeclareOptionParameter(Bar, "foo", nullptr, 0); // Duplicate option "foo"
+            CmdReader.RootCommand()->DeclareOptionParameter(Bar, "foo", nullptr, 0); // Duplicate option "foo"
         }
         catch (const InCommand::Exception& e)
         {
@@ -226,7 +226,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -239,7 +239,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -252,7 +252,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -265,7 +265,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
@@ -278,7 +278,7 @@ TEST(InCommand, Errors)
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
-        auto* pGotoCmd = CmdReader.DefaultCommand()->DeclareCommand("goto", nullptr, 1);
+        auto* pGotoCmd = CmdReader.RootCommand()->DeclareCommand("goto", nullptr, 1);
         pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         const char* barValues[] = { "1", "3", "5" };
         pGotoCmd->DeclareOptionParameter(Bar, "bar", 3, barValues, nullptr, 0);

--- a/src/test/InCommandTest.cpp
+++ b/src/test/InCommandTest.cpp
@@ -13,20 +13,20 @@ TEST(InCommand, BasicParams)
     };
     const int argc = sizeof(argv) / sizeof(argv[0]);
 
-    InCommand::InCommandBool IsReal;
-    InCommand::InCommandString Color;
-    InCommand::InCommandString Name("Fred");
+    InCommand::Bool IsReal;
+    InCommand::String Color;
+    InCommand::String Name("Fred");
 
     const char* colors[] = { "red", "green", "blue" };
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommandCtx()->DeclareSwitchOption(IsReal, "is-real", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareVariableOption(Name, "name", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareVariableOption(Color, "color", 3, colors, nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(IsReal, "is-real", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Name, "name", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Color, "color", 3, colors, nullptr);
 
     InCommand::CArgumentList args(argc, argv);
     InCommand::CArgumentIterator it = args.Begin();
-    CmdReader.ReadOptions();
+    CmdReader.ReadParameterArguments();
 
     EXPECT_TRUE(IsReal);
     EXPECT_EQ(std::string("Fred"),Name.Value());
@@ -45,18 +45,18 @@ TEST(InCommand, ParameterParams)
     };
     const int argc = sizeof(argv) / sizeof(argv[0]);
 
-    InCommand::InCommandBool SomeSwitch;
-    InCommand::InCommandString File1;
-    InCommand::InCommandString File2;
-    InCommand::InCommandString File3;
+    InCommand::Bool SomeSwitch;
+    InCommand::String File1;
+    InCommand::String File2;
+    InCommand::String File3;
 
     InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-    CmdReader.DefaultCommandCtx()->DeclareParameterOption(File1, "file1", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareParameterOption(File2, "file2", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareParameterOption(File3, "file3", nullptr);
-    CmdReader.DefaultCommandCtx()->DeclareSwitchOption(SomeSwitch, "some-switch", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File1, "file1", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File2, "file2", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareInputParameter(File3, "file3", nullptr);
+    CmdReader.DefaultCommandCtx()->DeclareBoolParameter(SomeSwitch, "some-switch", nullptr);
 
-    CmdReader.ReadOptions();
+    CmdReader.ReadParameterArguments();
 
     EXPECT_TRUE(SomeSwitch);
     EXPECT_EQ(File1.Value(), std::string(argv[1]));
@@ -85,21 +85,21 @@ TEST(InCommand, SubCommands)
 
     for(int i = 0; i < 3; ++i)
     {
-        InCommand::InCommandBool Help;
-        InCommand::InCommandBool List;
-        InCommand::InCommandBool Climb;
-        InCommand::InCommandBool Prune;
-        InCommand::InCommandBool Burn;
-        InCommand::InCommandBool Walk;
-        InCommand::InCommandString Lives("9");
+        InCommand::Bool Help;
+        InCommand::Bool List;
+        InCommand::Bool Climb;
+        InCommand::Bool Prune;
+        InCommand::Bool Burn;
+        InCommand::Bool Walk;
+        InCommand::String Lives("9");
 
         InCommand::CCommandReader CmdReader("app", "test argument list", 0, nullptr);
-        CmdReader.DefaultCommandCtx()->DeclareSwitchOption(Help, "help", nullptr);
+        CmdReader.DefaultCommandCtx()->DeclareBoolParameter(Help, "help", nullptr);
         InCommand::CCommandCtx* pPlantCommand = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("plant", nullptr, to_underlying(ScopeId::Plant));
-        pPlantCommand->DeclareSwitchOption(List, "list", nullptr);
+        pPlantCommand->DeclareBoolParameter(List, "list", nullptr);
         InCommand::CCommandCtx* pShrubCommand = pPlantCommand->DeclareCommandCtx("shrub", nullptr, to_underlying(ScopeId::Shrub));
-        pShrubCommand->DeclareSwitchOption(Prune, "prune", nullptr);
-        pShrubCommand->DeclareSwitchOption(Burn, "burn", nullptr);
+        pShrubCommand->DeclareBoolParameter(Prune, "prune", nullptr);
+        pShrubCommand->DeclareBoolParameter(Burn, "burn", nullptr);
         InCommand::CCommandCtx* pAnimalCommand = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("animal", nullptr, to_underlying(ScopeId::Animal));
         pAnimalCommand->DeclareCommandCtx("dog", nullptr, to_underlying(ScopeId::Dog));
         pAnimalCommand->DeclareCommandCtx("cat", nullptr, to_underlying(ScopeId::Cat));
@@ -109,16 +109,16 @@ TEST(InCommand, SubCommands)
             switch (static_cast<ScopeId>(pCommandScope->Id()))
             {
             case ScopeId::Tree:
-                pCommandScope->DeclareSwitchOption(Climb, "climb", nullptr);
+                pCommandScope->DeclareBoolParameter(Climb, "climb", nullptr);
                 break;
             case ScopeId::Animal:
-                pCommandScope->DeclareSwitchOption(List, "list", nullptr);
+                pCommandScope->DeclareBoolParameter(List, "list", nullptr);
                 break;
             case ScopeId::Dog:
-                pCommandScope->DeclareSwitchOption(Walk, "walk", nullptr);
+                pCommandScope->DeclareBoolParameter(Walk, "walk", nullptr);
                 break;
             case ScopeId::Cat:
-                pCommandScope->DeclareVariableOption(Lives, "lives", nullptr);
+                pCommandScope->DeclareOptionParameter(Lives, "lives", nullptr);
                 break;
             }
 
@@ -137,9 +137,9 @@ TEST(InCommand, SubCommands)
             const int argc = sizeof(argv) / sizeof(argv[0]);
 
             CmdReader.Reset(argc, argv);
-            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandCtx();
+            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
-            EXPECT_EQ(InCommand::InCommandStatus::Success, CmdReader.ReadOptions());
+            EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_TRUE(Burn);
             EXPECT_FALSE(Prune);
@@ -158,9 +158,9 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandCtx();
+            InCommand::CCommandCtx *pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
-            EXPECT_EQ(InCommand::InCommandStatus::Success, CmdReader.ReadOptions());
+            EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_EQ(Lives.Value(), std::string("8"));
 
@@ -175,9 +175,9 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommandCtx* pCtx = CmdReader.ReadCommandCtx();
+            InCommand::CCommandCtx* pCtx = CmdReader.ReadCommandArguments();
             LateDeclareOptions(pCtx);
-            EXPECT_EQ(InCommand::InCommandStatus::Success, CmdReader.ReadOptions());
+            EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_TRUE(Help);
 
@@ -188,8 +188,8 @@ TEST(InCommand, SubCommands)
 
 TEST(InCommand, Errors)
 {
-    InCommand::InCommandBool Foo;
-    InCommand::InCommandInt Bar;
+    InCommand::Bool Foo;
+    InCommand::Int Bar;
 
     {
         const char* argv[] = { "app", "goto", "--foo", "--bar" };
@@ -200,9 +200,9 @@ TEST(InCommand, Errors)
         {
             CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);; // Duplicate command "goto"
         }
-        catch(const InCommand::InCommandException& e)
+        catch(const InCommand::Exception& e)
         {
-            EXPECT_EQ(e.status, InCommand::InCommandStatus::DuplicateCommand);
+            EXPECT_EQ(e.status, InCommand::Status::DuplicateCommand);
         }
     }
     
@@ -210,14 +210,14 @@ TEST(InCommand, Errors)
         const char* argv[] = { "app", "goto", "--foo", "--bar", "7" };
         const int argc = sizeof(argv) / sizeof(argv[0]);
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
-        CmdReader.DefaultCommandCtx()->DeclareSwitchOption(Foo, "foo", nullptr, 0);
+        CmdReader.DefaultCommandCtx()->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         try
         {
-            CmdReader.DefaultCommandCtx()->DeclareVariableOption(Bar, "foo", nullptr, 0); // Duplicate option "foo"
+            CmdReader.DefaultCommandCtx()->DeclareOptionParameter(Bar, "foo", nullptr, 0); // Duplicate option "foo"
         }
-        catch (const InCommand::InCommandException& e)
+        catch (const InCommand::Exception& e)
         {
-            EXPECT_EQ(e.status, InCommand::InCommandStatus::DuplicateOption);
+            EXPECT_EQ(e.status, InCommand::Status::DuplicateOption);
         }
     }
 
@@ -227,10 +227,10 @@ TEST(InCommand, Errors)
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
         auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
-        pGotoCmd->DeclareSwitchOption(Foo, "foo", nullptr, 0);
-        pGotoCmd->DeclareVariableOption(Bar, "bar", nullptr, 0);
+        pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
-        EXPECT_EQ(InCommand::InCommandStatus::UnexpectedArgument, CmdReader.ReadOptions());
+        EXPECT_EQ(InCommand::Status::UnexpectedArgument, CmdReader.ReadParameterArguments());
         EXPECT_EQ(1, CmdReader.ReadIndex());
     }
 
@@ -240,10 +240,10 @@ TEST(InCommand, Errors)
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
         auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
-        pGotoCmd->DeclareSwitchOption(Foo, "foo", nullptr, 0);
-        pGotoCmd->DeclareVariableOption(Bar, "bar", nullptr, 0);
+        pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
-        EXPECT_EQ(InCommand::InCommandStatus::UnknownOption, CmdReader.ReadOptions());
+        EXPECT_EQ(InCommand::Status::UnknownOption, CmdReader.ReadParameterArguments());
         EXPECT_EQ(2, CmdReader.ReadIndex());
     }
 
@@ -253,10 +253,10 @@ TEST(InCommand, Errors)
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
         auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
-        pGotoCmd->DeclareSwitchOption(Foo, "foo", nullptr, 0);
-        pGotoCmd->DeclareVariableOption(Bar, "bar", nullptr, 0);
+        pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
-        EXPECT_EQ(InCommand::InCommandStatus::InvalidValue, CmdReader.ReadOptions());
+        EXPECT_EQ(InCommand::Status::InvalidValue, CmdReader.ReadParameterArguments());
         EXPECT_EQ(4, CmdReader.ReadIndex());
     }
 
@@ -266,10 +266,10 @@ TEST(InCommand, Errors)
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
         auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
-        pGotoCmd->DeclareSwitchOption(Foo, "foo", nullptr, 0);
-        pGotoCmd->DeclareVariableOption(Bar, "bar", nullptr, 0);
+        pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
+        pGotoCmd->DeclareOptionParameter(Bar, "bar", nullptr, 0);
 
-        EXPECT_EQ(InCommand::InCommandStatus::MissingOptionValue, CmdReader.ReadOptions());
+        EXPECT_EQ(InCommand::Status::MissingOptionValue, CmdReader.ReadParameterArguments());
         EXPECT_EQ(4, CmdReader.ReadIndex());
     }
 
@@ -279,11 +279,11 @@ TEST(InCommand, Errors)
         InCommand::CCommandReader CmdReader("app", "test argument list", argc, argv);
 
         auto* pGotoCmd = CmdReader.DefaultCommandCtx()->DeclareCommandCtx("goto", nullptr, 1);
-        pGotoCmd->DeclareSwitchOption(Foo, "foo", nullptr, 0);
+        pGotoCmd->DeclareBoolParameter(Foo, "foo", nullptr, 0);
         const char* barValues[] = { "1", "3", "5" };
-        pGotoCmd->DeclareVariableOption(Bar, "bar", 3, barValues, nullptr, 0);
+        pGotoCmd->DeclareOptionParameter(Bar, "bar", 3, barValues, nullptr, 0);
 
-        EXPECT_EQ(InCommand::InCommandStatus::InvalidValue, CmdReader.ReadOptions());
+        EXPECT_EQ(InCommand::Status::InvalidValue, CmdReader.ReadParameterArguments());
         EXPECT_EQ(4, CmdReader.ReadIndex());
     }
 }

--- a/src/test/InCommandTest.cpp
+++ b/src/test/InCommandTest.cpp
@@ -137,8 +137,8 @@ TEST(InCommand, SubCommands)
             const int argc = sizeof(argv) / sizeof(argv[0]);
 
             CmdReader.Reset(argc, argv);
-            InCommand::CCommand *pCtx = CmdReader.ReadCommandArguments();
-            LateDeclareOptions(pCtx);
+            InCommand::CCommand *pCommand = CmdReader.ReadCommandArguments();
+            LateDeclareOptions(pCommand);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_TRUE(Burn);
@@ -158,8 +158,8 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommand *pCtx = CmdReader.ReadCommandArguments();
-            LateDeclareOptions(pCtx);
+            InCommand::CCommand *pCommand = CmdReader.ReadCommandArguments();
+            LateDeclareOptions(pCommand);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_EQ(Lives.Value(), std::string("8"));
@@ -175,8 +175,8 @@ TEST(InCommand, SubCommands)
 
             CmdReader.Reset(argc, argv);
 
-            InCommand::CCommand* pCtx = CmdReader.ReadCommandArguments();
-            LateDeclareOptions(pCtx);
+            InCommand::CCommand* pCommand = CmdReader.ReadCommandArguments();
+            LateDeclareOptions(pCommand);
             EXPECT_EQ(InCommand::Status::Success, CmdReader.ReadParameterArguments());
 
             EXPECT_TRUE(Help);


### PR DESCRIPTION
Also makes CCommandReader a CCommand-derived class, simplifying the overall InCommand APIs.